### PR TITLE
fix: use process.env for runtime env var resolution on Vercel

### DIFF
--- a/src/components/Generator.astro
+++ b/src/components/Generator.astro
@@ -4,10 +4,10 @@ import StopIcon from "./icons/Stop.astro";
 ---
 
 <footer class="container">
-  <div class="provider-selector" id="providerSelector">
-    <button class="provider-btn active" data-provider="openai">OpenAI</button>
-    <button class="provider-btn" data-provider="claude">Claude</button>
-    <button class="provider-btn" data-provider="gemini">Gemini</button>
+  <div class="provider-selector" id="providerSelector" style="display:none;">
+    <button class="provider-btn" data-provider="openai" style="display:none;">OpenAI</button>
+    <button class="provider-btn" data-provider="claude" style="display:none;">Claude</button>
+    <button class="provider-btn" data-provider="gemini" style="display:none;">Gemini</button>
   </div>
   <form action="#" id="messageForm">
     <div class="autogrow">
@@ -110,9 +110,14 @@ import StopIcon from "./icons/Stop.astro";
         }
       }
 
+      // Only show selector if more than one provider is available
+      if (availableProviders.length > 1) {
+        providerSelector.style.display = "";
+      }
+
       updateProviderUI();
     } catch {
-      // If loading fails, show all buttons as fallback
+      // If loading fails, keep selector hidden
     }
   }
 

--- a/src/pages/api.ts
+++ b/src/pages/api.ts
@@ -1,7 +1,7 @@
 import {
   generatePayload,
   parseStream,
-  providerConfigs,
+  getProviderConfig,
   getAvailableProviders,
 } from "../utils/generate";
 import type { APIRoute } from "astro";
@@ -10,12 +10,7 @@ import type { Provider } from "../types";
 export const prerender = false;
 
 export const GET: APIRoute = async () => {
-  const available = getAvailableProviders();
-  const providers = available.map((p) => ({
-    id: p,
-    label: providerConfigs[p].label,
-    model: providerConfigs[p].model,
-  }));
+  const providers = getAvailableProviders();
   return new Response(JSON.stringify({ providers }), {
     headers: { "Content-Type": "application/json" },
   });
@@ -38,7 +33,7 @@ export const POST: APIRoute = async (context) => {
         ? rawProvider
         : "openai";
 
-    const cfg = providerConfigs[provider];
+    const cfg = getProviderConfig(provider);
     if (!cfg.apiKey) {
       return new Response(
         JSON.stringify({

--- a/src/utils/generate.ts
+++ b/src/utils/generate.ts
@@ -2,37 +2,53 @@ import { createParser } from "eventsource-parser";
 import type { ParsedEvent, ReconnectInterval } from "eventsource-parser";
 import type { ChatMessage, Provider } from "../types";
 
-// --- Provider configs from environment ---
+// --- Provider configs from environment (read at runtime via process.env) ---
 
-export const providerConfigs = {
-  openai: {
-    apiKey: import.meta.env.OPENAI_API_KEY || "",
-    model: import.meta.env.OPENAI_API_MODEL || "gpt-5.4-mini",
-    endpoint: (
-      import.meta.env.OPENAI_API_ENDPOINT ||
-      "https://api.openai.com/v1/chat/completions"
-    ).trim().replace(/\/$/, ""),
-    label: "OpenAI",
-  },
-  claude: {
-    apiKey: import.meta.env.CLAUDE_API_KEY || "",
-    model: import.meta.env.CLAUDE_API_MODEL || "claude-haiku-4-5",
-    endpoint: "https://api.anthropic.com/v1/messages",
-    label: "Claude",
-  },
-  gemini: {
-    apiKey: import.meta.env.GEMINI_API_KEY || "",
-    model: import.meta.env.GEMINI_API_MODEL || "gemini-3-flash-preview",
-    endpoint: "https://generativelanguage.googleapis.com/v1beta",
-    label: "Gemini",
-  },
-};
+interface ProviderConfig {
+  apiKey: string;
+  model: string;
+  endpoint: string;
+  label: string;
+}
 
-// Which providers have API keys configured
-export function getAvailableProviders(): Provider[] {
-  return (Object.keys(providerConfigs) as Provider[]).filter(
-    (p) => !!providerConfigs[p].apiKey
-  );
+export function getProviderConfig(provider: Provider): ProviderConfig {
+  switch (provider) {
+    case "openai":
+      return {
+        apiKey: process.env.OPENAI_API_KEY || "",
+        model: process.env.OPENAI_API_MODEL || "gpt-5.4-mini",
+        endpoint: (
+          process.env.OPENAI_API_ENDPOINT ||
+          "https://api.openai.com/v1/chat/completions"
+        ).trim().replace(/\/$/, ""),
+        label: "OpenAI",
+      };
+    case "claude":
+      return {
+        apiKey: process.env.CLAUDE_API_KEY || "",
+        model: process.env.CLAUDE_API_MODEL || "claude-haiku-4-5",
+        endpoint: "https://api.anthropic.com/v1/messages",
+        label: "Claude",
+      };
+    case "gemini":
+      return {
+        apiKey: process.env.GEMINI_API_KEY || "",
+        model: process.env.GEMINI_API_MODEL || "gemini-3-flash-preview",
+        endpoint: "https://generativelanguage.googleapis.com/v1beta",
+        label: "Gemini",
+      };
+  }
+}
+
+const ALL_PROVIDERS: Provider[] = ["openai", "claude", "gemini"];
+
+export function getAvailableProviders(): { id: Provider; label: string; model: string }[] {
+  return ALL_PROVIDERS
+    .map((p) => {
+      const cfg = getProviderConfig(p);
+      return cfg.apiKey ? { id: p, label: cfg.label, model: cfg.model } : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
 }
 
 // --- Payload generation per provider ---
@@ -51,7 +67,7 @@ function generateOpenAIPayload(
   messages: ChatMessage[],
   temperature: number
 ): { url: string; init: RequestInit } {
-  const cfg = providerConfigs.openai;
+  const cfg = getProviderConfig("openai");
   return {
     url: cfg.endpoint,
     init: {
@@ -74,7 +90,7 @@ function generateClaudePayload(
   messages: ChatMessage[],
   temperature: number
 ): { url: string; init: RequestInit } {
-  const cfg = providerConfigs.claude;
+  const cfg = getProviderConfig("claude");
   const { system, userMessages } = extractSystemMessage(messages);
 
   // Claude requires alternating user/assistant. Merge consecutive same-role.
@@ -117,7 +133,7 @@ function generateGeminiPayload(
   messages: ChatMessage[],
   temperature: number
 ): { url: string; init: RequestInit } {
-  const cfg = providerConfigs.gemini;
+  const cfg = getProviderConfig("gemini");
   const { system, userMessages } = extractSystemMessage(messages);
 
   const contents = userMessages.map((msg) => ({


### PR DESCRIPTION
import.meta.env values are inlined at build time by Vite, causing provider availability to be frozen to build-time state. Switching to process.env ensures serverless functions read environment variables at runtime, so adding/removing API keys on Vercel takes effect without redeploying code.

Also hides provider selector buttons by default to prevent flash of unavailable providers before the /api response arrives.

https://claude.ai/code/session_017Mninm9LynqaAVG9A3Knqd